### PR TITLE
Minor fixes in service data record processing

### DIFF
--- a/pkg/egtslib/service_data_records.go
+++ b/pkg/egtslib/service_data_records.go
@@ -154,7 +154,7 @@ func (s *ServiceDataSet) Encode() ([]byte, error) {
 		}
 
 		if sdr.TimeFieldExists == "1" {
-			if binary.Write(buf, binary.LittleEndian, sdr.Time); err != nil {
+			if err := binary.Write(buf, binary.LittleEndian, sdr.Time); err != nil {
 				return result, fmt.Errorf("Не удалось время формирования записи на стороне отправителя SDR: %v", err)
 			}
 		}

--- a/pkg/egtslib/service_data_records.go
+++ b/pkg/egtslib/service_data_records.go
@@ -155,7 +155,7 @@ func (s *ServiceDataSet) Encode() ([]byte, error) {
 
 		if sdr.TimeFieldExists == "1" {
 			if err := binary.Write(buf, binary.LittleEndian, sdr.Time); err != nil {
-				return result, fmt.Errorf("Не удалось время формирования записи на стороне отправителя SDR: %v", err)
+				return result, fmt.Errorf("Не удалось записать время формирования записи на стороне отправителя SDR: %v", err)
 			}
 		}
 


### PR DESCRIPTION
Incorrect err value was compared with nil since binary.Write result was ignored 
Type in error message - missed word